### PR TITLE
allow to specify the certificate signature algorithm

### DIFF
--- a/lib/eassl/certificate.rb
+++ b/lib/eassl/certificate.rb
@@ -52,8 +52,8 @@ module EaSSL
       @ssl
     end
 
-    def sign(ca_key)
-      ssl.sign(ca_key.private_key, OpenSSL::Digest::SHA1.new)
+    def sign(ca_key, digest=OpenSSL::Digest::SHA1.new)
+      ssl.sign(ca_key.private_key, digest)
     end
 
     def to_pem

--- a/lib/eassl/certificate_authority.rb
+++ b/lib/eassl/certificate_authority.rb
@@ -27,7 +27,7 @@ module EaSSL
       self.new(:key => key, :certificate => certificate, :serial => serial)
     end
 
-    def create_certificate(signing_request, type='server', days_valid=nil)
+    def create_certificate(signing_request, type='server', days_valid=nil, digest=OpenSSL::Digest::SHA1.new)
       options = {
         :signing_request => signing_request,
         :ca_certificate => @certificate,
@@ -39,7 +39,7 @@ module EaSSL
       end
       cert = Certificate.new(options)
       @serial.save!
-      cert.sign(@key)
+      cert.sign(@key, digest)
       cert
     end
   end

--- a/lib/eassl/signing_request.rb
+++ b/lib/eassl/signing_request.rb
@@ -10,6 +10,7 @@ module EaSSL
       @options = {
         :name       => {},                #required, CertificateName
         :key        => nil,               #required
+        :digest     => OpenSSL::Digest::SHA1.new,
       }.update(options)
       @options[:key] ||= Key.new(@options)
     end
@@ -20,7 +21,7 @@ module EaSSL
         @ssl.version = 0
         @ssl.subject = CertificateName.new(@options[:name].options).name
         @ssl.public_key = key.public_key
-        @ssl.sign(key.private_key, OpenSSL::Digest::SHA1.new)
+        @ssl.sign(key.private_key, @options[:digest])
       end
       @ssl
     end


### PR DESCRIPTION
SHA1 certificates are phased out, we need a mechanism to be able to specify the digest alghorithm used to sign the requested certificates with. The double defaults are to provide backwards compatibility.
